### PR TITLE
Add support of PlainText authentication provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ app:
   refreshDiscoveryPeriodInSec: 600
   # Prometheus http server port endpoint
   httpServerPort: 8080
+  # Optional: username used to auth to cassandra
+  # username: user
+  # Optional: password used to auth to cassandra
+  # password: password
 
 discovery:
   dns:

--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,10 @@ app:
   refreshDiscoveryPeriodInSec: 600
   # Prometheus http server port endpoint
   httpServerPort: 8080
+  # Optional: username used to auth to cassandra
+  # username: user
+  # Optional: password used to auth to cassandra
+  # password: password
 
 discovery:
   dns:


### PR DESCRIPTION
Limitation: same user and password should be set on all cassnadra cluster monitored
by a casspoke instance
Only supprt PlainTextAuthProvider

Solved #2 