### PR TITLE
Replace release action by upload action

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -21,21 +21,8 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
 
-    - uses: ncipollo/release-action@v1
-      with:
-        artifacts: "build/libs/*.jar"
-        bodyFile: ""
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Get release version
-      id: get_version
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
-      
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.14
-      with:
-        name: criteord/casspoke
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: docker/Dockerfile 
-        tags: "latest,${{ env.RELEASE_VERSION }}"
+    - name: Upload
+      uses: fnkr/github-action-ghr@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GHR_PATH: build/libs/


### PR DESCRIPTION
Since release are now handled via github we just need to upload the jar